### PR TITLE
Add default metrics settings

### DIFF
--- a/frinx/common/telemetry/metrics.py
+++ b/frinx/common/telemetry/metrics.py
@@ -38,10 +38,11 @@ class Metrics(metaclass=MetricsSingletonMeta):
     settings: MetricsSettings
 
     def __init__(self, settings: MetricsSettings | None = None):
-
         if settings is not None:
             self.settings = settings
             self.__init_collector()
+        else:
+            self.settings = MetricsSettings(metrics_enabled=False)
 
     def __init_collector(self) -> None:
         if self.settings.metrics_enabled:


### PR DESCRIPTION
No settings in initialized Metrics object cause runtime errors.


>     "    metrics.increment_counter(",
>     "  File \"/frinx_python_sdk/frinx/common/telemetry/metrics.py\", line 55, in increment_counter",
>     "    if self.settings.metrics_enabled:",
>     "AttributeError: 'Metrics' object has no attribute 'settings'"