### PR TITLE
Add pass_task_error_to_task_output and pass_task_error_to_task_output_path to TaskExecutionProperties

### DIFF
--- a/frinx/common/worker/task_def.py
+++ b/frinx/common/worker/task_def.py
@@ -120,6 +120,7 @@ class TaskExecutionProperties(BaseModel):
     exclude_empty_inputs: bool = False
     transform_string_to_json_valid: bool = False
     pass_worker_input_exception_to_task_output: bool = False
+    pass_task_error_to_task_output: bool = True
     worker_input_exception_task_output_path: str = 'result.error'
 
     model_config = ConfigDict(

--- a/frinx/common/worker/task_def.py
+++ b/frinx/common/worker/task_def.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from typing import Optional
 
 from pydantic import BaseModel
@@ -119,9 +120,16 @@ class FailedTaskError(ConductorWorkerError):
 class TaskExecutionProperties(BaseModel):
     exclude_empty_inputs: bool = False
     transform_string_to_json_valid: bool = False
-    pass_worker_input_exception_to_task_output: bool = False
     pass_task_error_to_task_output: bool = True
-    worker_input_exception_task_output_path: str = 'result.error'
+    pass_task_error_to_task_output_path: str = 'result.error'
+    pass_worker_input_exception_to_task_output: bool = Field(
+        default=False,
+        description='deprecation_flag',
+    )
+    worker_input_exception_task_output_path: str = Field(
+        default='result.error',
+        description='deprecation_flag',
+    )
 
     model_config = ConfigDict(
         frozen=True,
@@ -130,3 +138,34 @@ class TaskExecutionProperties(BaseModel):
         arbitrary_types_allowed=False,
         populate_by_name=False
     )
+
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+        self._handle_deprecated_fields()
+
+    def _handle_deprecated_fields(self) -> None:
+        import logging
+        import warnings
+
+        logger = logging.getLogger(__name__)
+
+        if self.model_fields['pass_worker_input_exception_to_task_output'].description != 'deprecation_flag':
+            message = (
+                "The 'pass_worker_input_exception_to_task_output' field is deprecated and should not be used. "
+                "Use 'pass_task_error_to_task_output' instead."
+            )
+            warnings.warn(message, DeprecationWarning)
+            logger.warning(message)
+            object.__setattr__(self, 'pass_task_error_to_task_output',
+                               self.pass_worker_input_exception_to_task_output)
+
+        if self.model_fields['worker_input_exception_task_output_path'].description != 'deprecation_flag':
+            message = (
+                "The 'worker_input_exception_task_output_path' field is deprecated and should not be used. "
+                "Use 'pass_task_error_to_task_output_path' instead."
+            )
+            warnings.warn(message, DeprecationWarning)
+            logger.warning(message)
+
+            object.__setattr__(self, 'pass_task_error_to_task_output_path',
+                               self.worker_input_exception_task_output_path)

--- a/frinx/common/worker/worker.py
+++ b/frinx/common/worker/worker.py
@@ -227,10 +227,10 @@ class WorkerImpl:
         if execution_properties.pass_task_error_to_task_output:
             match error:
                 case ValidationError():
-                    error_info: DictAny = self._validate_exception_format(error)
+                    error_info: str | DictAny = self._validate_exception_format(error)
                 case _:
-                    error_info: str = str(error)
-            task_result.output = TaskOutput(error={'error_name': error_name, 'error_info': error_info})
+                    error_info = str(error)
+            task_result.output = TaskOutput(**{'error': {'error_name': error_name, 'error_info': error_info}})
         else:
             match error:
                 case ValidationError():

--- a/frinx/common/worker/worker.py
+++ b/frinx/common/worker/worker.py
@@ -224,27 +224,21 @@ class WorkerImpl:
             logs=[TaskExecLog(f'{error_name}: {error}')]
         )
 
-        if execution_properties.pass_task_error_to_task_output:
+        if execution_properties.pass_worker_input_exception_to_task_output:
             match error:
                 case ValidationError():
                     error_info: str | DictAny = self._validate_exception_format(error)
                 case _:
                     error_info = str(error)
-            task_result.output = TaskOutput(**{'error': {'error_name': error_name, 'error_info': error_info}})
-        else:
-            match error:
-                case ValidationError():
-                    formatted_error: DictAny = self._validate_exception_format(error)
-                    task_result.logs = [TaskExecLog(f'{error_name}: {formatted_error}')]
 
-                    if execution_properties.pass_worker_input_exception_to_task_output:
-                        task_result.output = self._parse_exception_output_path_to_dict(
-                            dot_path={
-                                execution_properties.worker_input_exception_task_output_path: formatted_error
-                            }
-                        )
+            error_dict = {'error_name': error_name, 'error_info': error_info}
+            error_dict_with_output_path = self._parse_exception_output_path_to_dict(
+                dot_path={execution_properties.pass_task_error_to_task_output_path: error_dict})
 
-        logger.error('%s error occurred: %s \n%s', error_name, error, str(traceback.format_exc()))
+            task_result.output = TaskOutput(**error_dict_with_output_path)
+
+            logger.error('%s error occurred: %s \n%s', error_name, error, str(traceback.format_exc()))
+
         return task_result
 
     def execute_wrapper(self, task: RawTaskIO) -> Any:

--- a/tests/unit_tests/common_test/worker_test/test_task_def.py
+++ b/tests/unit_tests/common_test/worker_test/test_task_def.py
@@ -202,33 +202,20 @@ class TestTaskGenerator:
             )
         )
 
-        response: DictAny = DictAny({
-           'status': 'FAILED',
-           'output': {
-              'output': {
-                 'error': {
-                    'string_list': {
-                       'type': 'missing',
-                       'message': 'Field required'
-                    },
-                    'and_dict': {
-                       'type': 'missing',
-                       'message': 'Field required'
-                    },
-                    'required_string': {
-                       'type': 'missing',
-                       'message': 'Field required'
-                    }
-                 }
-              }
-           },
-           'logs': [
-              "ValidationError: {'string_list': {'type': 'missing', 'message': 'Field required'}, "
-              "'and_dict': {'type': 'missing', 'message': 'Field required'}, 'required_string': "
-              "{'type': 'missing', 'message': 'Field required'}}"
-           ]
-        })
+        expected_result = {'output': {'error': {'error_name': 'ValidationError',
+                                                'error_info':
+                                                    {
+                                                        'string_list':
+                                                            {'type': 'missing', 'message': 'Field required'},
+                                                        'and_dict':
+                                                            {'type': 'missing', 'message': 'Field required'},
+                                                        'required_string':
+                                                            {'type': 'missing', 'message': 'Field required'}
+                                                    }
+                                                }
+                                      }
+                           }
 
         worker = MockExecuteProperties()
         result = worker.execute_wrapper(task=worker_input_dict)
-        assert result == response
+        assert result.get('output') == expected_result


### PR DESCRIPTION
- Added pass_task_error_to_task_output attribute to TaskExecutionProperties.
- Implemented error handling to pass detailed error information to task output.