### PR TITLE
Fix exception response handler

### DIFF
--- a/frinx/common/worker/worker.py
+++ b/frinx/common/worker/worker.py
@@ -224,7 +224,7 @@ class WorkerImpl:
             logs=[TaskExecLog(f'{error_name}: {error}')]
         )
 
-        if execution_properties.pass_worker_input_exception_to_task_output:
+        if execution_properties.pass_task_error_to_task_output:
             match error:
                 case ValidationError():
                     error_info: str | DictAny = self._validate_exception_format(error)


### PR DESCRIPTION
- Updated exception_response_handler to check execution_properties.pass_task_error_to_task_output instead of execution_properties.pass_worker_input_exception_to_task_output.