### PR TITLE
Add custom TaskLogHandler to manage thread-specific logs

### DIFF
--- a/frinx/client/v2/frinx_conductor_wrapper.py
+++ b/frinx/client/v2/frinx_conductor_wrapper.py
@@ -24,17 +24,12 @@ import requests
 
 from frinx.client.v2.conductor import WFClientMgr
 from frinx.common.frinx_rest import CONDUCTOR_URL_BASE
-from frinx.common.logging.task_logging import TaskLogHandler
+from frinx.common.logging.task_logging import task_log_handler
 from frinx.common.worker.worker import WorkerImpl
 
 logger = logging.getLogger(__name__)
 hostname = socket.gethostname()
 RawTaskIO: TypeAlias = dict[str, Any]
-
-task_logger = logging.getLogger('task_logger')
-task_logger.propagate = False
-task_log_handler = TaskLogHandler(max_capacity=100, max_message_length=15000)
-task_logger.addHandler(task_log_handler)
 
 
 @dataclass
@@ -244,7 +239,7 @@ class FrinxConductorWrapper:
 
     def execute(self, task: RawTaskIO, task_blueprint: WorkerImpl) -> None:
         try:
-            task_log_handler.set_taskname_for_thread(task['taskType'])
+            task_log_handler.set_task_info_for_thread(str(task['taskType']), str(task['workflowInstanceId']))
             logger.info('Executing a task %s', task['taskId'])
             resp = task_blueprint.execute_wrapper(task)
 

--- a/frinx/common/logging/task_logging.py
+++ b/frinx/common/logging/task_logging.py
@@ -1,0 +1,92 @@
+import logging
+import threading
+from collections import deque
+
+
+class TaskLogHandler(logging.Handler):
+    """
+    A custom logging handler that stores log messages in a thread-specific queue,
+    creates a log list, and prints formatted log messages to the console.
+
+    Attributes:
+        max_capacity (int): Maximum number of log messages to retain in the queue.
+        max_message_length (int): Maximum length of each log message.
+        thread_data (threading.local): Thread-local storage for log data.
+        formatter (logging.Formatter): Formatter for internal log storage.
+        console_formatter (logging.Formatter): Formatter for console output.
+        console_handler (logging.StreamHandler): Handler for console output.
+    """
+
+    def __init__(self, max_capacity: int = 100, max_message_length: int = 15000, level: int = logging.INFO) -> None:
+        super().__init__(level)
+        self.max_capacity: int = max_capacity
+        self.max_message_length: int = max_message_length
+        self.thread_data = threading.local()
+        self.thread_data.log_queue = deque(maxlen=self.max_capacity)
+        self.thread_data.task_name = 'Unknown'
+        self.formatter = logging.Formatter('%(levelname)s: %(message)s')
+        self.console_formatter = logging.Formatter(
+            '%(asctime)s | %(threadName)s | %(levelname)s | task: %(taskname)s | %(message)s', datefmt='%F %T')
+        self.console_handler = logging.StreamHandler()
+        self.console_handler.setFormatter(self.console_formatter)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """
+        Emit a log record.
+        Store the log record in the thread-specific queue and print it to the console.
+        """
+        if not hasattr(self.thread_data, 'log_queue'):
+            self._setup_thread_logging()
+
+        if not hasattr(self.thread_data, 'task_name'):
+            self.thread_data.task_name = 'Unknown'
+
+        record.taskname = self.thread_data.task_name
+
+        formatted_record: str = self.format(record)
+        truncated_record: str = self._truncate_message(formatted_record)
+        self.thread_data.log_queue.append(truncated_record)
+
+        self.console_handler.emit(record)
+
+    def _truncate_message(self, message: str) -> str:
+        """
+        Truncate a message if it exceeds the maximum message length.
+        """
+        if len(message) > self.max_message_length:
+            return message[:self.max_message_length] + '... [truncated]'
+        return message
+
+    def _setup_thread_logging(self) -> None:
+        """
+        Setup thread-specific logging.
+        """
+        self.thread_data.log_queue = deque(maxlen=self.max_capacity)
+
+    def set_taskname_for_thread(self, task_name: str) -> None:
+        """
+        Set the task name for the current thread.
+        """
+        self.thread_data.task_name = task_name
+
+    def get_logs(self, clear: bool = True) -> list[str]:
+        """
+        Get the logs for the current thread.
+        """
+        if not hasattr(self.thread_data, 'log_queue'):
+            return []
+
+        logs: list[str] = list(self.thread_data.log_queue)
+
+        if clear:
+            self.thread_data.log_queue.clear()
+            self._clear_taskname_for_thread()
+
+        return logs
+
+    def _clear_taskname_for_thread(self) -> None:
+        """
+        Clear the task name for the current thread.
+        """
+        if hasattr(self.thread_data, 'task_name'):
+            del self.thread_data.task_name


### PR DESCRIPTION
- Implemented TaskLogHandler class to store and manage log messages in a thread-specific queue.
- Configured TaskLogHandler in frinx_conductor_wrapper to append logs and set name for thread.