### PR TITLE
Fix: Change O to 0 in TEST_simulate_retryable_error and add traceback

### DIFF
--- a/examples/simple_worker/workers/test_worker.py
+++ b/examples/simple_worker/workers/test_worker.py
@@ -232,7 +232,7 @@ class TestWorkers(ServiceWorkersImpl):
                 Raises an exception on the first three executions and succeeds on the fourth.
                 """
                 env_var_name: str = f'{self.__class__.__name__}_attempt_count'
-                attempt_count: int = int(os.getenv(env_var_name, 'O'))
+                attempt_count: int = int(os.getenv(env_var_name, '0'))
 
                 try:
                     if attempt_count < 3:  # noqa: PLR2004

--- a/frinx/common/worker/worker.py
+++ b/frinx/common/worker/worker.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import logging
+import sys
 import time
+import traceback
 from abc import abstractmethod
 from functools import reduce
 from json import JSONDecodeError
@@ -266,6 +268,7 @@ class WorkerImpl:
             logger.debug('Task result %s:', task_result)
             return task_result
         except Exception as error:
+            sys.stderr.write(traceback.format_exc())
             increment_task_execution_error(metrics, task_type, error)
             increment_uncaught_exception(metrics, task_type)
             return self.exception_response_handler(


### PR DESCRIPTION
- Corrected the incorrect assignment of the attempt count in TEST_simulate_retryable_error:
  - Changed from `int(os.getenv(env_var_name, 'O'))` to `int(os.getenv(env_var_name, '0'))`.

- Improved error handling in the execute_wrapper function:
  - Added `sys.stderr.write(traceback.format_exc())` to log detailed traceback information when an exception occurs.